### PR TITLE
fixed bad file names for posterior samples

### DIFF
--- a/03_analysis_scripts/train-single-model.R
+++ b/03_analysis_scripts/train-single-model.R
@@ -259,8 +259,8 @@ if (mode == "prod" & method == "bart") {
       mutate(set="unlabelled") 
     )
   
-  write_csv(ppd_samples, file.path(output_dir, paste0(name, "-ppd-samples.csv")))
-  write_csv(ev_samples, file.path(output_dir, paste0(name, "-ev-samples.csv")))
+  write_csv(ppd_samples, file.path(output_dir, "final-ppd-samples.csv"))
+  write_csv(ev_samples, file.path(output_dir, "final-ev-samples.csv"))
 }
 
 ### feature importance ----


### PR DESCRIPTION
old-style file names were still in there for the posterior sample files for BART, causing an error because `name` is not created in the script any more